### PR TITLE
Series of small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ This code uses the ```skTMVA``` class from ```https://github.com/yuraic/koza4ok`
 
 # Example: testing previously trained classifier on BSM inputs -- NB. be careful about double counting here
 ./run_classifier.py --input inputs/X275_hh.root --exclude Delta_phi_jb --strategy sklBDT --ftrain 0 --training_sample SM_merged
+
 ./run_classifier.py --input inputs/X300_hh.root --exclude Delta_phi_jb --strategy sklBDT --ftrain 0 --training_sample SM_merged
+
 ./run_classifier.py --input inputs/X325_hh.root --exclude Delta_phi_jb --strategy sklBDT --ftrain 0 --training_sample SM_merged
+
 ./run_classifier.py --input inputs/X350_hh.root --exclude Delta_phi_jb --strategy sklBDT --ftrain 0 --training_sample SM_merged
+
 ./run_classifier.py --input inputs/X400_hh.root --exclude Delta_phi_jb --strategy sklBDT --ftrain 0 --training_sample SM_merged
 
 # Example: training and testing on all inputs

--- a/bbyy_jet_classifier/plotting/plot_asimov.py
+++ b/bbyy_jet_classifier/plotting/plot_asimov.py
@@ -1,0 +1,33 @@
+import matplotlib.pyplot as plt
+import matplotlib
+import cPickle
+import numpy as np
+
+def bdt_mhmatch_ratio(data, strategy, lower_bound):
+
+	matplotlib.rcParams.update({'font.size': 16})
+	plt.hlines(1, lower_bound, 0.95, linestyles='dashed', linewidth=0.5)
+	color = iter(plt.cm.rainbow(np.linspace(0, 1, len(data.keys()))))
+
+	for ss in sorted(data.keys()): # loop thru the different signal samples
+		c = next(color)
+		if len(data[ss]['BDT'][1]) > 1:
+			_ = plt.plot(data[ss]['BDT'][0], data[ss]['BDT'][1] / data[ss]['mHmatch'][1], label=ss, color=c, linewidth=2)
+			maxidx = np.argmax((data[ss]['BDT'][1] / data[ss]['mHmatch'][1])[:-1])
+			_ = plt.scatter(
+				data[ss]['BDT'][0][maxidx], 
+				(data[ss]['BDT'][1] / data[ss]['mHmatch'][1])[maxidx],
+				color=c
+				)
+		else:
+			raise ValueError("There are no data points to plot for class " + ss)
+
+	plt.xlabel('BDT Threshold Value')
+	plt.ylabel(r'$Z_{\mathrm{Asimov}}^{\mathrm{BDT}} / Z_{\mathrm{Asimov}}^{\mathrm{mHmatch}}$')
+	plt.xlim(xmin=lower_bound, xmax=0.95)
+	plt.ylim(ymin=0.2, ymax=2.8)
+
+	plt.legend(loc='upper left')
+	plt.savefig('threshold_ratio_{}.pdf'.format(strategy))
+	plt.show()
+	plt.clf()

--- a/bbyy_jet_classifier/plotting/plot_outputs.py
+++ b/bbyy_jet_classifier/plotting/plot_outputs.py
@@ -59,7 +59,7 @@ def confusion(ML_strategy, yhat, data, model_name, sample_name):
         Args:
         -----
                 ML_strategy = one of the machine learning strategy in strategies/ whose prerformance we want to visualize
-                yhat = the array of predictions
+                yhat = the array of binary predictions {0, 1}
                 data = dictionary, containing 'y', 'w' for the set to evaluate performance on, where:
                     y = array of dim (# examples) with target values
                     w = array of dim (# examples) with event weights
@@ -75,21 +75,24 @@ def confusion(ML_strategy, yhat, data, model_name, sample_name):
         plt.imshow(cm, interpolation='nearest', cmap=cmap)
         plt.title(title)
         plt.colorbar()
-        tick_marks = np.arange(len(np.unique(y_test)))
+        tick_marks = [0, 1] #np.arange(len(np.unique(y_test)))
         plt.xticks(tick_marks, ['Incorrect', 'Correct'])
         plt.yticks(tick_marks, ['Incorrect', 'Correct'], rotation='vertical')
         plt.ylabel('True Label')
         plt.xlabel('Predicted Label')
         plt.tight_layout()
 
-    # -- need to round yhat to nearest integer (0 or 1) to match y_test format
-    #    NB. this is equivalent to cutting at the halfway point of the distribution
-    cm = confusion_matrix(y_test, np.rint(yhat))
+    cm = confusion_matrix(y_test, yhat)
     # Normalize the confusion matrix by row (i.e by the number of samples in each class)
     cm_normalized = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
     _plot_confusion_matrix(cm_normalized, title='Normalized Confusion Matrix')
     ensure_directory(os.path.join(ML_strategy.output_directory, "testing", sample_name))
-    plt.savefig(os.path.join(ML_strategy.output_directory, "testing", sample_name, "{}_confusion_{}.pdf".format(model_name, sample_name)))
+    plt.savefig(os.path.join(
+        ML_strategy.output_directory, 
+        "testing", 
+        sample_name, 
+        "{}_confusion_{}.pdf".format(model_name, sample_name)
+        ))
     plt.close(figure)
 
 
@@ -110,6 +113,7 @@ def classifier_output(ML_strategy, yhat, data, process, sample_name):
             sample_name = arbitrary string that refers back to the input file, usually
     """
     # -- Initialise figure, axes and binning
+    plt.clf()
     logging.getLogger("plot_outputs").info("Plotting classifier output on {} set for {}".format(process, sample_name))
     plot_atlas.set_style()
     figure = plt.figure(figsize=(6, 6), dpi=100)

--- a/bbyy_jet_classifier/process_data.py
+++ b/bbyy_jet_classifier/process_data.py
@@ -8,7 +8,7 @@ from sklearn.feature_selection import SelectKBest, f_classif
 
 TYPE_2_CHAR = {"int32": "I", "float64": "D", "float32": "F"}
 
-def load(input_filename, excluded_variables, training_fraction, max_events):
+def load(input_filename, treename, excluded_variables, training_fraction, max_events):
     """
     Definition:
     -----------
@@ -45,7 +45,7 @@ def load(input_filename, excluded_variables, training_fraction, max_events):
     for v_name in excluded_variables:
         logging.getLogger("process_data").info("... excluding variable {}".format(v_name))
     # -- import all root files into data_rec
-    data_rec = root2array(input_filename, "events_1tag")
+    data_rec = root2array(input_filename, treename)
     # -- ordered dictionary of branches and their type
     variable2type = OrderedDict(((v_name, TYPE_2_CHAR[data_rec[v_name][0].dtype.name]) for v_name in data_rec.dtype.names
                                  if v_name not in excluded_variables))

--- a/bbyy_jet_classifier/strategies/root_tmva.py
+++ b/bbyy_jet_classifier/strategies/root_tmva.py
@@ -2,6 +2,7 @@ import array
 import logging
 import os
 import shutil
+import numpy as np
 from ROOT import TCut, TFile, TMVA
 from root_numpy.tmva import add_classification_events, evaluate_reader
 from . import BaseStrategy
@@ -90,4 +91,7 @@ class RootTMVA(BaseStrategy):
         # reader.BookMVA("BDT", os.path.join(self.output_directory, training_sample, "skl_BDT", "classifier", "skl_BDT_TMVA.weights.xml"))
 
         yhat = evaluate_reader(reader, "BDT", test_data["X"])
-        return yhat
+        # -- add binary classification labels
+        yhat_class = np.zeros(len(yhat))
+        yhat_class[yhat >= 0] = 1
+        return yhat, yhat_class

--- a/bbyy_jet_classifier/strategies/skl_BDT.py
+++ b/bbyy_jet_classifier/strategies/skl_BDT.py
@@ -4,9 +4,11 @@ import os
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.externals import joblib
 from sklearn.metrics import classification_report
+from sklearn.grid_search import GridSearchCV
 from . import BaseStrategy
 from ..utils import ensure_directory
 
+GRID_SEARCH = False
 
 class sklBDT(BaseStrategy):
     """
@@ -31,16 +33,35 @@ class sklBDT(BaseStrategy):
         """
         # -- Train:
         logging.getLogger("skl_BDT").info("Training...")
-        classifier = GradientBoostingClassifier(
-            n_estimators=300, 
-            min_samples_split=0.5 * len(train_data["y"]), 
-            max_depth=15, 
-            verbose=1
-            )
-        classifier.fit(train_data["X"], train_data["y"], sample_weight=train_data["w"])
+
+        if GRID_SEARCH: # -- useful, I wouln't erase it completely
+        # -- however, we should probably pass this as an argument instead of defining this on top of the file
+            param_grid = { # change these parameters if you want to test different options
+               'n_estimators' : [50, 100, 200, 300], 
+               'min_samples_split' : [2, 5],
+               'max_depth': [3, 5, 7, 10]
+            }
+            fit_params = {
+                'sample_weight' : train_data['w']
+            }
+            metaclassifier = GridSearchCV(GradientBoostingClassifier(), param_grid=param_grid, fit_params=fit_params, 
+                #scoring=event_accuracy, TO BE IMPLEMENTED! 
+                cv=2, n_jobs=4, verbose=1)
+            metaclassifier.fit(train_data['X'], train_data['y'])
+            classifier = metaclassifier.best_estimator_
+            print metaclassifier.best_params_
+
+        else:
+            classifier = GradientBoostingClassifier(
+                n_estimators=300, 
+                min_samples_split=0.5 * len(train_data["y"]), 
+                max_depth=15, 
+                verbose=1
+                )
+            classifier.fit(train_data["X"], train_data["y"], sample_weight=train_data["w"])
 
         # -- Dump output to pickle
-        ensure_directory(os.path.join(self.output_directory, sample_name, self.name, "classifier", ))
+        ensure_directory(os.path.join(self.output_directory, sample_name, self.name, "classifier"))
         joblib.dump(classifier, os.path.join(self.output_directory, sample_name, self.name, "classifier", "skl_BDT_clf.pkl"), protocol=cPickle.HIGHEST_PROTOCOL)
 
         # Save BDT to TMVA xml file
@@ -49,7 +70,11 @@ class sklBDT(BaseStrategy):
             from skTMVA import convert_bdt_sklearn_tmva
             logging.getLogger("skl_BDT").info("Exporting output to TMVA XML file")
             variables = [ (v,variable_dict[v]) for v in classification_variables ]
-            convert_bdt_sklearn_tmva(classifier, variables, os.path.join(self.output_directory, sample_name, self.name, "classifier", "skl_BDT_TMVA.weights.xml"))
+            convert_bdt_sklearn_tmva(
+                classifier,
+                variables,
+                os.path.join(self.output_directory, sample_name, self.name, "classifier", "skl_BDT_TMVA.weights.xml")
+                )
         except ImportError:
             logging.getLogger("skl_BDT").info("Could not import skTMVA. Skipping export to TMVA output.")
 

--- a/bbyy_jet_classifier/strategies/skl_BDT.py
+++ b/bbyy_jet_classifier/strategies/skl_BDT.py
@@ -31,7 +31,12 @@ class sklBDT(BaseStrategy):
         """
         # -- Train:
         logging.getLogger("skl_BDT").info("Training...")
-        classifier = GradientBoostingClassifier(n_estimators=300, min_samples_split=2, max_depth=15, verbose=1)
+        classifier = GradientBoostingClassifier(
+            n_estimators=300, 
+            min_samples_split=0.5 * len(train_data["y"]), 
+            max_depth=15, 
+            verbose=1
+            )
         classifier.fit(train_data["X"], train_data["y"], sample_weight=train_data["w"])
 
         # -- Dump output to pickle

--- a/bbyy_jet_classifier/strategies/skl_BDT.py
+++ b/bbyy_jet_classifier/strategies/skl_BDT.py
@@ -31,7 +31,7 @@ class sklBDT(BaseStrategy):
         """
         # -- Train:
         logging.getLogger("skl_BDT").info("Training...")
-        classifier = GradientBoostingClassifier(n_estimators=300, min_samples_split=2, max_depth=10, verbose=1)
+        classifier = GradientBoostingClassifier(n_estimators=300, min_samples_split=2, max_depth=15, verbose=1)
         classifier.fit(train_data["X"], train_data["y"], sample_weight=train_data["w"])
 
         # -- Dump output to pickle
@@ -74,11 +74,17 @@ class sklBDT(BaseStrategy):
         classifier = joblib.load(os.path.join(self.output_directory, training_sample, self.name, "classifier", "skl_BDT_clf.pkl"))
 
         # -- Get classifier predictions
-        yhat = classifier.predict_proba(test_data["X"])[:, 1]
+        yhat = classifier.predict_proba(test_data["X"])[:, 1] # extracting column 1, i.e. P(signal)
+        yhat_class = classifier.predict(test_data["X"])
 
         # -- Log classification scores
         logging.getLogger("skl_BDT").info("accuracy = {:.2f}%".format(100 * classifier.score(test_data["X"], test_data["y"], sample_weight=test_data["w"])))
-        for output_line in classification_report(test_data["y"], classifier.predict(test_data["X"]), target_names=["correct", "incorrect"], sample_weight=test_data["w"]).splitlines():
+        for output_line in classification_report(
+                test_data["y"], 
+                yhat_class, 
+                target_names=["correct", "incorrect"], 
+                sample_weight=test_data["w"]
+                ).splitlines():
             logging.getLogger("skl_BDT").info(output_line)
 
-        return yhat
+        return yhat, yhat_class

--- a/run_classifier.py
+++ b/run_classifier.py
@@ -12,6 +12,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Run ML algorithms over ROOT TTree input")
 
     parser.add_argument("--input", required=True, type=str, nargs="+", help="input file names")
+    parser.add_argument("--tree", type=str, help="name of the tree in the ntuples", default="events_1tag")
     parser.add_argument("--output", type=str, help="output directory", default="output")
     parser.add_argument("--exclude", type=str, nargs="+", default=[], metavar="VARIABLE_NAME", help="list of variables to exclude")
     parser.add_argument("--ftrain", type=float, default=0.6, help="fraction of events to use for training")
@@ -68,7 +69,7 @@ if __name__ == "__main__":
         classification_variables, variable2type,\
             training_data[input_samples[-1]], testing_data[input_samples[-1]],\
             yhat_old_test_data[input_samples[-1]], test_events_data[input_samples[-1]]\
-            = process_data.load(input_filename, args.exclude, args.ftrain, args.max_events)
+            = process_data.load(input_filename, args.tree, args.exclude, args.ftrain, args.max_events)
 
         #-- Plot input distributions
         plot_inputs.input_distributions(classification_variables, training_data[input_samples[-1]], testing_data[input_samples[-1]],
@@ -100,7 +101,7 @@ if __name__ == "__main__":
             # -- (only useful if you care to check the performance on the training set)
             for (sample_name, train_data) in training_data.items():
                 logger.info("Sanity check: testing global classifier output on training set {}".format(sample_name))
-                yhat_train = ML_strategy.test(train_data, classification_variables, training_sample=combined_input_sample)
+                yhat_train, yhat_class_train = ML_strategy.test(train_data, classification_variables, training_sample=combined_input_sample)
                 plot_outputs.classifier_output(ML_strategy, yhat_train, train_data, process="training", sample_name=sample_name)
 
         else:
@@ -115,11 +116,11 @@ if __name__ == "__main__":
                 logger.info("Running classifier from {} on testing set for {}".format(training_sample, sample_name))
 
                 # -- Test classifier
-                yhat_test = ML_strategy.test(test_data, classification_variables, training_sample=training_sample)
+                yhat_test, yhat_class_test = ML_strategy.test(test_data, classification_variables, training_sample=training_sample)
 
                 # -- Plot output testing distributions from classifier
                 plot_outputs.classifier_output(ML_strategy, yhat_test, test_data, process="testing", sample_name=sample_name)
-                plot_outputs.confusion(ML_strategy, yhat_test, test_data, ML_strategy.name, sample_name=sample_name)
+                plot_outputs.confusion(ML_strategy, yhat_class_test, test_data, ML_strategy.name, sample_name=sample_name)
 
                 # -- Plot yhat output for the old strategies
                 for old_strategy_name in old_strategy_names:


### PR DESCRIPTION
Hey James,

Here's the list of changes I made, ordered neatly by commit:
1) The confusion matrix was still not binary for TMVA even after your rounding hack, because the output of TMVA ranges from -1 to 1, so rounding to the closest integer created 3 possible outcomes (-1, 0, 1). I made it such that the `test()` function returns both the probabilities (`yhat`) and the class that has the highest probability (`yhat_class`), which I manually forced to be either 0 or 1 for both classes, so that the confusion matrix turns out okay. The confusion matrix is the only place in the code where `yhat_class` is used, so this doesn't mess up anything else.

2) I added the possibility of passing the name of the TTree as an arguments when we run the classifier, just because I was still running with old samples where the tree is called "events"

3) Partially fixed (or at least understood) the issue with the weird negative loss in sklearn --> min samples split was too low + negative weights?

4) Re-added ability of running a grid search over the bdt parameters using sklearn

5) The event level performance evaluation now automatically produces a plot of Z_BDT/Z_mHmatch for different samples and values of the threshold.
